### PR TITLE
Support controllers plugged into the original famicom's exp port

### DIFF
--- a/src/memory.asm
+++ b/src/memory.asm
@@ -8,8 +8,8 @@
 .org $00
 
 setpos $F5
-joy_pressed: .res 2 ; the buttons on controllers that were *just* pressed this frame, one byte for each controller
-joy_held: .res 2 ; the buttons on controller that were pressed this frame, including those pressed last frame too, one byte for each controller
+joy_pressed: .res 3 ; the buttons on controllers that were *just* pressed this frame, one byte for each controller, and an extra byte for extended buttons on controller 1
+joy_held: .res 3 ; the buttons on controller that were pressed this frame, including those pressed last frame too, one byte for each controller, and an extra byte for extended buttons on controller 1
 
 .segment "BSS"
 .org $300

--- a/src/prg0.asm
+++ b/src/prg0.asm
@@ -2119,7 +2119,12 @@ Spell_Casting_Routine:                                                          
     BEQ      L8E1F                     ; 0xde4 $8DD4 F0 49                     ;
     LDA      joy_pressed+0                       ; 0xde6 $8DD6 A5 F5                     ; Controller 1 buttons pressed
     AND      #$20                      ; 0xde8 $8DD8 29 20                     ; check if Select is pressed
-    BEQ      L8E1F                     ; 0xdea $8DDA F0 43                     ; if Select NOT pressed, skip to $0E1F
+    ;BEQ      L8E1F                     ; 0xdea $8DDA F0 43                     ; if Select NOT pressed, skip to $0E1F
+    BNE      :+ ; instead branch to the "next part" if it IS pressed
+    LDA      joy_pressed+2
+    AND      #%10100000 ; SNES A or L pressed
+    BEQ      L8E1F ; and then branch away if A on the extended buttons is ALSO not pressed.
+:
     LDY      bss_0749                     ; 0xdec $8DDC AC 49 07                  ; Current position of the Magic selector
     LDA      player_spells,y                   ; 0xdef $8DDF B9 7B 07                  ; Sanity Check...
     BEQ      L8E1F                     ; 0xdf2 $8DE2 F0 3B                     ; if Magic is not learned, skip to $0E1F

--- a/src/prg7.asm
+++ b/src/prg7.asm
@@ -2934,10 +2934,11 @@ LD330:                                                                         ;
 ; read the 8 bits from the JOY[x] registers into the joy[x]_pressed globals, one bit per iteration
     LDX      #$08                      ; 0x1d380 $D370 A2 08                   ; X = #$08 0000_1000
     @Loop:                                                                         ;
-    ; right shift from JOY1 into the carry flag
+    ; check if D0 or D1 are set in JOY1, to allow for Famicom expansion port controller 1
         LDA      JOY1                      ; 0x1d382 $D372 AD 16 40                ;
-        LSR                                ; 0x1d385 $D375 4A                      ;
-    ; left shift the carry flag into joy_pressed+0
+        and      #%11
+        cmp      #$01
+    ; left shift the carry flag into joy_pressed[0]
         ROL      joy_pressed+0                       ; 0x1d386 $D376 26 F5                   ; Controller 1 Buttons Pressed
     ; right shift from JOY2 into the carry flag
         LDA      JOY2                      ; 0x1d388 $D378 AD 17 40                ;


### PR DESCRIPTION
In order to do this, you have to read from both of the first two bits of the controller register, since D1 will have the inputs from the expansion port's controller.

Note: This change moves other code around, so may not be a safe patch to apply with other random patches.